### PR TITLE
fix: resolve ES module import issue with marked library

### DIFF
--- a/nodes/Substack/MarkdownParser.ts
+++ b/nodes/Substack/MarkdownParser.ts
@@ -1,11 +1,4 @@
-import { marked } from 'marked';
 import type { OwnProfile } from 'substack-api';
-
-// Configure marked library
-marked.setOptions({
-	gfm: true,
-	breaks: false
-});
 
 // Helper function to decode HTML entities
 function decodeHtmlEntities(text: string): string {
@@ -30,10 +23,19 @@ export class MarkdownParser {
 	 * Parse markdown text and apply it to a NoteBuilder using structured approach
 	 * Returns the final ParagraphBuilder with all content applied (handles immutable builders)
 	 */
-	static parseMarkdownToNoteStructured(markdown: string, noteBuilder: ReturnType<OwnProfile['newNote']>): ReturnType<ReturnType<OwnProfile['newNote']>['paragraph']> {
+	static async parseMarkdownToNoteStructured(markdown: string, noteBuilder: ReturnType<OwnProfile['newNote']>): Promise<ReturnType<ReturnType<OwnProfile['newNote']>['paragraph']>> {
 		if (!markdown.trim()) {
 			throw new Error('Note body cannot be empty - at least one paragraph with content is required');
 		}
+
+		// Dynamically import marked library
+		const { marked } = await import('marked');
+		
+		// Configure marked library
+		marked.setOptions({
+			gfm: true,
+			breaks: false
+		});
 
 		// Parse markdown into tokens using marked
 		const tokens = marked.lexer(markdown);
@@ -70,8 +72,8 @@ export class MarkdownParser {
 	/**
 	 * Legacy method for backward compatibility
 	 */
-	static parseMarkdownToNote(markdown: string, noteBuilder: ReturnType<OwnProfile['newNote']>): ReturnType<ReturnType<OwnProfile['newNote']>['paragraph']> {
-		return this.parseMarkdownToNoteStructured(markdown, noteBuilder);
+	static async parseMarkdownToNote(markdown: string, noteBuilder: ReturnType<OwnProfile['newNote']>): Promise<ReturnType<ReturnType<OwnProfile['newNote']>['paragraph']>> {
+		return await this.parseMarkdownToNoteStructured(markdown, noteBuilder);
 	}
 
 	/**

--- a/nodes/Substack/Note.operations.ts
+++ b/nodes/Substack/Note.operations.ts
@@ -235,7 +235,7 @@ async function createAdvancedNote(
 	}
 	
 	try {
-		const finalBuilder = MarkdownParser.parseMarkdownToNoteStructured(body.trim(), ownProfile.newNote());
+		const finalBuilder = await MarkdownParser.parseMarkdownToNoteStructured(body.trim(), ownProfile.newNote());
 		return await finalBuilder.publish();
 	} catch (error) {
 		let userMessage = error.message;

--- a/tests/unit/markdown-parser.test.ts
+++ b/tests/unit/markdown-parser.test.ts
@@ -100,7 +100,7 @@ describe('MarkdownParser - Real NoteBuilder', () => {
 			const profile = await mockSubstackClient.ownProfile();
 			const noteBuilder = profile.newNote();
 			
-			const result = MarkdownParser.parseMarkdownToNoteStructured(markdown, noteBuilder);
+			const result = await MarkdownParser.parseMarkdownToNoteStructured(markdown, noteBuilder);
 			await result.publish();
 
 			expect(capturedPayload).toMatchObject(expectedJson);
@@ -132,7 +132,7 @@ describe('MarkdownParser - Real NoteBuilder', () => {
 			const profile = await mockSubstackClient.ownProfile();
 			const noteBuilder = profile.newNote();
 			
-			const result = MarkdownParser.parseMarkdownToNoteStructured(markdown, noteBuilder);
+			const result = await MarkdownParser.parseMarkdownToNoteStructured(markdown, noteBuilder);
 			await result.publish();
 
 			expect(capturedPayload).toMatchObject(expectedJson);
@@ -164,7 +164,7 @@ describe('MarkdownParser - Real NoteBuilder', () => {
 			const profile = await mockSubstackClient.ownProfile();
 			const noteBuilder = profile.newNote();
 			
-			const result = MarkdownParser.parseMarkdownToNoteStructured(markdown, noteBuilder);
+			const result = await MarkdownParser.parseMarkdownToNoteStructured(markdown, noteBuilder);
 			await result.publish();
 
 			expect(capturedPayload).toMatchObject(expectedJson);
@@ -196,7 +196,7 @@ describe('MarkdownParser - Real NoteBuilder', () => {
 			const profile = await mockSubstackClient.ownProfile();
 			const noteBuilder = profile.newNote();
 			
-			const result = MarkdownParser.parseMarkdownToNoteStructured(markdown, noteBuilder);
+			const result = await MarkdownParser.parseMarkdownToNoteStructured(markdown, noteBuilder);
 			await result.publish();
 
 			expect(capturedPayload).toMatchObject(expectedJson);
@@ -246,7 +246,7 @@ describe('MarkdownParser - Real NoteBuilder', () => {
 			const profile = await mockSubstackClient.ownProfile();
 			const noteBuilder = profile.newNote();
 			
-			const result = MarkdownParser.parseMarkdownToNoteStructured(markdown, noteBuilder);
+			const result = await MarkdownParser.parseMarkdownToNoteStructured(markdown, noteBuilder);
 			await result.publish();
 
 			expect(capturedPayload).toMatchObject(expectedJson);
@@ -272,7 +272,7 @@ describe('MarkdownParser - Real NoteBuilder', () => {
 			const profile = await mockSubstackClient.ownProfile();
 			const noteBuilder = profile.newNote();
 			
-			const result = MarkdownParser.parseMarkdownToNoteStructured(markdown, noteBuilder);
+			const result = await MarkdownParser.parseMarkdownToNoteStructured(markdown, noteBuilder);
 			await result.publish();
 
 			expect(capturedPayload).toMatchObject(expectedJson);
@@ -330,7 +330,7 @@ describe('MarkdownParser - Real NoteBuilder', () => {
 			const profile = await mockSubstackClient.ownProfile();
 			const noteBuilder = profile.newNote();
 			
-			const result = MarkdownParser.parseMarkdownToNoteStructured(markdown, noteBuilder);
+			const result = await MarkdownParser.parseMarkdownToNoteStructured(markdown, noteBuilder);
 			await result.publish();
 
 			expect(capturedPayload).toMatchObject(expectedJson);
@@ -397,7 +397,7 @@ Second paragraph with *italic* text.`;
 			const profile = await mockSubstackClient.ownProfile();
 			const noteBuilder = profile.newNote();
 			
-			const result = MarkdownParser.parseMarkdownToNoteStructured(markdown, noteBuilder);
+			const result = await MarkdownParser.parseMarkdownToNoteStructured(markdown, noteBuilder);
 			await result.publish();
 
 			expect(capturedPayload).toMatchObject(expectedJson);
@@ -430,7 +430,7 @@ Second paragraph with *italic* text.`;
 			const profile = await mockSubstackClient.ownProfile();
 			const noteBuilder = profile.newNote();
 			
-			const result = MarkdownParser.parseMarkdownToNoteStructured(markdown, noteBuilder);
+			const result = await MarkdownParser.parseMarkdownToNoteStructured(markdown, noteBuilder);
 			await result.publish();
 
 			expect(capturedPayload).toMatchObject(expectedJson);
@@ -469,7 +469,7 @@ Second paragraph with *italic* text.`;
 			const profile = await mockSubstackClient.ownProfile();
 			const noteBuilder = profile.newNote();
 			
-			const result = MarkdownParser.parseMarkdownToNoteStructured(markdown, noteBuilder);
+			const result = await MarkdownParser.parseMarkdownToNoteStructured(markdown, noteBuilder);
 			await result.publish();
 
 			expect(capturedPayload).toMatchObject(expectedJson);
@@ -509,7 +509,7 @@ Second paragraph with *italic* text.`;
 			const profile = await mockSubstackClient.ownProfile();
 			const noteBuilder = profile.newNote();
 			
-			const result = MarkdownParser.parseMarkdownToNoteStructured(markdown, noteBuilder);
+			const result = await MarkdownParser.parseMarkdownToNoteStructured(markdown, noteBuilder);
 			await result.publish();
 
 			expect(capturedPayload).toMatchObject(expectedJson);
@@ -547,7 +547,7 @@ Second paragraph with *italic* text.`;
 			const profile = await mockSubstackClient.ownProfile();
 			const noteBuilder = profile.newNote();
 			
-			const result = MarkdownParser.parseMarkdownToNoteStructured(markdown, noteBuilder);
+			const result = await MarkdownParser.parseMarkdownToNoteStructured(markdown, noteBuilder);
 			await result.publish();
 
 			expect(capturedPayload).toMatchObject(expectedJson);
@@ -591,7 +591,7 @@ Second paragraph with *italic* text.`;
 			const profile = await mockSubstackClient.ownProfile();
 			const noteBuilder = profile.newNote();
 			
-			const result = MarkdownParser.parseMarkdownToNoteStructured(markdown, noteBuilder);
+			const result = await MarkdownParser.parseMarkdownToNoteStructured(markdown, noteBuilder);
 			await result.publish();
 
 			expect(capturedPayload).toMatchObject(expectedJson);
@@ -622,7 +622,7 @@ Second paragraph with *italic* text.`;
 			const profile = await mockSubstackClient.ownProfile();
 			const noteBuilder = profile.newNote();
 			
-			const result = MarkdownParser.parseMarkdownToNoteStructured(markdown, noteBuilder);
+			const result = await MarkdownParser.parseMarkdownToNoteStructured(markdown, noteBuilder);
 			await result.publish();
 
 			expect(capturedPayload).toMatchObject(expectedJson);
@@ -728,7 +728,7 @@ Final paragraph.`;
 			const profile = await mockSubstackClient.ownProfile();
 			const noteBuilder = profile.newNote();
 			
-			const result = MarkdownParser.parseMarkdownToNoteStructured(markdown, noteBuilder);
+			const result = await MarkdownParser.parseMarkdownToNoteStructured(markdown, noteBuilder);
 			await result.publish();
 
 			expect(capturedPayload).toMatchObject(expectedJson);
@@ -740,36 +740,28 @@ Final paragraph.`;
 			const profile = await mockSubstackClient.ownProfile();
 			const noteBuilder = profile.newNote();
 			
-			expect(() => {
-				MarkdownParser.parseMarkdownToNoteStructured('', noteBuilder);
-			}).toThrow('Note body cannot be empty - at least one paragraph with content is required');
+			await expect(MarkdownParser.parseMarkdownToNoteStructured('', noteBuilder)).rejects.toThrow('Note body cannot be empty - at least one paragraph with content is required');
 		});
 
 		it('should throw error for whitespace-only markdown', async () => {
 			const profile = await mockSubstackClient.ownProfile();
 			const noteBuilder = profile.newNote();
 			
-			expect(() => {
-				MarkdownParser.parseMarkdownToNoteStructured('   \n\t  ', noteBuilder);
-			}).toThrow('Note body cannot be empty - at least one paragraph with content is required');
+			await expect(MarkdownParser.parseMarkdownToNoteStructured('   \n\t  ', noteBuilder)).rejects.toThrow('Note body cannot be empty - at least one paragraph with content is required');
 		});
 
 		it('should throw error for empty headings', async () => {
 			const profile = await mockSubstackClient.ownProfile();
 			const noteBuilder = profile.newNote();
 			
-			expect(() => {
-				MarkdownParser.parseMarkdownToNoteStructured('## \n### \n#### ', noteBuilder);
-			}).toThrow('Note must contain at least one paragraph with actual content');
+			await expect(MarkdownParser.parseMarkdownToNoteStructured('## \n### \n#### ', noteBuilder)).rejects.toThrow('Note must contain at least one paragraph with actual content');
 		});
 
 		it('should throw error for empty list items only', async () => {
 			const profile = await mockSubstackClient.ownProfile();
 			const noteBuilder = profile.newNote();
 			
-			expect(() => {
-				MarkdownParser.parseMarkdownToNoteStructured('- \n* \n1. ', noteBuilder);
-			}).toThrow('Note must contain at least one paragraph with actual content');
+			await expect(MarkdownParser.parseMarkdownToNoteStructured('- \n* \n1. ', noteBuilder)).rejects.toThrow('Note must contain at least one paragraph with actual content');
 		});
 	});
 });


### PR DESCRIPTION
- Convert static import to dynamic import for marked library
- Make MarkdownParser methods async to support dynamic imports
- Update Note.operations.ts to handle async MarkdownParser calls
- Fix test file to use await with async MarkdownParser methods
- Resolves n8n loading error: "require() of ES Module not supported"