### PR TITLE
fix: downgrade marked library to v4.x.x for CommonJS compatibility

### DIFF
--- a/nodes/Substack/MarkdownParser.ts
+++ b/nodes/Substack/MarkdownParser.ts
@@ -1,4 +1,11 @@
+import { marked } from 'marked';
 import type { OwnProfile } from 'substack-api';
+
+// Configure marked library
+marked.setOptions({
+	gfm: true,
+	breaks: false
+});
 
 // Helper function to decode HTML entities
 function decodeHtmlEntities(text: string): string {
@@ -23,19 +30,10 @@ export class MarkdownParser {
 	 * Parse markdown text and apply it to a NoteBuilder using structured approach
 	 * Returns the final ParagraphBuilder with all content applied (handles immutable builders)
 	 */
-	static async parseMarkdownToNoteStructured(markdown: string, noteBuilder: ReturnType<OwnProfile['newNote']>): Promise<ReturnType<ReturnType<OwnProfile['newNote']>['paragraph']>> {
+	static parseMarkdownToNoteStructured(markdown: string, noteBuilder: ReturnType<OwnProfile['newNote']>): ReturnType<ReturnType<OwnProfile['newNote']>['paragraph']> {
 		if (!markdown.trim()) {
 			throw new Error('Note body cannot be empty - at least one paragraph with content is required');
 		}
-
-		// Dynamically import marked library
-		const { marked } = await import('marked');
-		
-		// Configure marked library
-		marked.setOptions({
-			gfm: true,
-			breaks: false
-		});
 
 		// Parse markdown into tokens using marked
 		const tokens = marked.lexer(markdown);
@@ -72,8 +70,8 @@ export class MarkdownParser {
 	/**
 	 * Legacy method for backward compatibility
 	 */
-	static async parseMarkdownToNote(markdown: string, noteBuilder: ReturnType<OwnProfile['newNote']>): Promise<ReturnType<ReturnType<OwnProfile['newNote']>['paragraph']>> {
-		return await this.parseMarkdownToNoteStructured(markdown, noteBuilder);
+	static parseMarkdownToNote(markdown: string, noteBuilder: ReturnType<OwnProfile['newNote']>): ReturnType<ReturnType<OwnProfile['newNote']>['paragraph']> {
+		return this.parseMarkdownToNoteStructured(markdown, noteBuilder);
 	}
 
 	/**

--- a/nodes/Substack/Note.operations.ts
+++ b/nodes/Substack/Note.operations.ts
@@ -235,7 +235,7 @@ async function createAdvancedNote(
 	}
 	
 	try {
-		const finalBuilder = await MarkdownParser.parseMarkdownToNoteStructured(body.trim(), ownProfile.newNote());
+		const finalBuilder = MarkdownParser.parseMarkdownToNoteStructured(body.trim(), ownProfile.newNote());
 		return await finalBuilder.publish();
 	} catch (error) {
 		let userMessage = error.message;

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,12 +9,12 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
-        "marked": "^16.1.1",
+        "marked": "^4.3.0",
         "substack-api": "^1.3.0"
       },
       "devDependencies": {
         "@types/jest": "^30.0.0",
-        "@types/marked": "^5.0.2",
+        "@types/marked": "^4.3.2",
         "@typescript-eslint/parser": "~8.38.0",
         "eslint": "^9.29.0",
         "eslint-plugin-n8n-nodes-base": "^1.16.3",
@@ -1832,9 +1832,9 @@
       "license": "MIT"
     },
     "node_modules/@types/marked": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/@types/marked/-/marked-5.0.2.tgz",
-      "integrity": "sha512-OucS4KMHhFzhz27KxmWg7J+kIYqyqoW5kdIEI319hqARQQUTqhao3M/F+uFnDXD0Rg72iDDZxZNxq5gvctmLlg==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@types/marked/-/marked-4.3.2.tgz",
+      "integrity": "sha512-a79Yc3TOk6dGdituy8hmTTJXjOkZ7zsFYV10L337ttq/rec8lRMDBpV7fL3uLx6TgbFCa5DU/h8FmIBQPSbU0w==",
       "dev": true,
       "license": "MIT"
     },
@@ -6802,15 +6802,15 @@
       }
     },
     "node_modules/marked": {
-      "version": "16.1.1",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-16.1.1.tgz",
-      "integrity": "sha512-ij/2lXfCRT71L6u0M29tJPhP0bM5shLL3u5BePhFwPELj2blMJ6GDtD7PfJhRLhJ/c2UwrK17ySVcDzy2YHjHQ==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.3.0.tgz",
+      "integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==",
       "license": "MIT",
       "bin": {
         "marked": "bin/marked.js"
       },
       "engines": {
-        "node": ">= 20"
+        "node": ">= 12"
       }
     },
     "node_modules/math-intrinsics": {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   },
   "devDependencies": {
     "@types/jest": "^30.0.0",
-    "@types/marked": "^5.0.2",
+    "@types/marked": "^4.3.2",
     "@typescript-eslint/parser": "~8.38.0",
     "eslint": "^9.29.0",
     "eslint-plugin-n8n-nodes-base": "^1.16.3",
@@ -59,7 +59,7 @@
     "n8n-workflow": "^1.82.0"
   },
   "dependencies": {
-    "marked": "^16.1.1",
+    "marked": "^4.3.0",
     "substack-api": "^1.3.0"
   }
 }

--- a/tests/unit/markdown-parser.test.ts
+++ b/tests/unit/markdown-parser.test.ts
@@ -100,7 +100,7 @@ describe('MarkdownParser - Real NoteBuilder', () => {
 			const profile = await mockSubstackClient.ownProfile();
 			const noteBuilder = profile.newNote();
 			
-			const result = await MarkdownParser.parseMarkdownToNoteStructured(markdown, noteBuilder);
+			const result = MarkdownParser.parseMarkdownToNoteStructured(markdown, noteBuilder);
 			await result.publish();
 
 			expect(capturedPayload).toMatchObject(expectedJson);
@@ -132,7 +132,7 @@ describe('MarkdownParser - Real NoteBuilder', () => {
 			const profile = await mockSubstackClient.ownProfile();
 			const noteBuilder = profile.newNote();
 			
-			const result = await MarkdownParser.parseMarkdownToNoteStructured(markdown, noteBuilder);
+			const result = MarkdownParser.parseMarkdownToNoteStructured(markdown, noteBuilder);
 			await result.publish();
 
 			expect(capturedPayload).toMatchObject(expectedJson);
@@ -164,7 +164,7 @@ describe('MarkdownParser - Real NoteBuilder', () => {
 			const profile = await mockSubstackClient.ownProfile();
 			const noteBuilder = profile.newNote();
 			
-			const result = await MarkdownParser.parseMarkdownToNoteStructured(markdown, noteBuilder);
+			const result = MarkdownParser.parseMarkdownToNoteStructured(markdown, noteBuilder);
 			await result.publish();
 
 			expect(capturedPayload).toMatchObject(expectedJson);
@@ -196,7 +196,7 @@ describe('MarkdownParser - Real NoteBuilder', () => {
 			const profile = await mockSubstackClient.ownProfile();
 			const noteBuilder = profile.newNote();
 			
-			const result = await MarkdownParser.parseMarkdownToNoteStructured(markdown, noteBuilder);
+			const result = MarkdownParser.parseMarkdownToNoteStructured(markdown, noteBuilder);
 			await result.publish();
 
 			expect(capturedPayload).toMatchObject(expectedJson);
@@ -246,7 +246,7 @@ describe('MarkdownParser - Real NoteBuilder', () => {
 			const profile = await mockSubstackClient.ownProfile();
 			const noteBuilder = profile.newNote();
 			
-			const result = await MarkdownParser.parseMarkdownToNoteStructured(markdown, noteBuilder);
+			const result = MarkdownParser.parseMarkdownToNoteStructured(markdown, noteBuilder);
 			await result.publish();
 
 			expect(capturedPayload).toMatchObject(expectedJson);
@@ -272,7 +272,7 @@ describe('MarkdownParser - Real NoteBuilder', () => {
 			const profile = await mockSubstackClient.ownProfile();
 			const noteBuilder = profile.newNote();
 			
-			const result = await MarkdownParser.parseMarkdownToNoteStructured(markdown, noteBuilder);
+			const result = MarkdownParser.parseMarkdownToNoteStructured(markdown, noteBuilder);
 			await result.publish();
 
 			expect(capturedPayload).toMatchObject(expectedJson);
@@ -330,7 +330,7 @@ describe('MarkdownParser - Real NoteBuilder', () => {
 			const profile = await mockSubstackClient.ownProfile();
 			const noteBuilder = profile.newNote();
 			
-			const result = await MarkdownParser.parseMarkdownToNoteStructured(markdown, noteBuilder);
+			const result = MarkdownParser.parseMarkdownToNoteStructured(markdown, noteBuilder);
 			await result.publish();
 
 			expect(capturedPayload).toMatchObject(expectedJson);
@@ -397,7 +397,7 @@ Second paragraph with *italic* text.`;
 			const profile = await mockSubstackClient.ownProfile();
 			const noteBuilder = profile.newNote();
 			
-			const result = await MarkdownParser.parseMarkdownToNoteStructured(markdown, noteBuilder);
+			const result = MarkdownParser.parseMarkdownToNoteStructured(markdown, noteBuilder);
 			await result.publish();
 
 			expect(capturedPayload).toMatchObject(expectedJson);
@@ -430,7 +430,7 @@ Second paragraph with *italic* text.`;
 			const profile = await mockSubstackClient.ownProfile();
 			const noteBuilder = profile.newNote();
 			
-			const result = await MarkdownParser.parseMarkdownToNoteStructured(markdown, noteBuilder);
+			const result = MarkdownParser.parseMarkdownToNoteStructured(markdown, noteBuilder);
 			await result.publish();
 
 			expect(capturedPayload).toMatchObject(expectedJson);
@@ -469,7 +469,7 @@ Second paragraph with *italic* text.`;
 			const profile = await mockSubstackClient.ownProfile();
 			const noteBuilder = profile.newNote();
 			
-			const result = await MarkdownParser.parseMarkdownToNoteStructured(markdown, noteBuilder);
+			const result = MarkdownParser.parseMarkdownToNoteStructured(markdown, noteBuilder);
 			await result.publish();
 
 			expect(capturedPayload).toMatchObject(expectedJson);
@@ -509,7 +509,7 @@ Second paragraph with *italic* text.`;
 			const profile = await mockSubstackClient.ownProfile();
 			const noteBuilder = profile.newNote();
 			
-			const result = await MarkdownParser.parseMarkdownToNoteStructured(markdown, noteBuilder);
+			const result = MarkdownParser.parseMarkdownToNoteStructured(markdown, noteBuilder);
 			await result.publish();
 
 			expect(capturedPayload).toMatchObject(expectedJson);
@@ -547,7 +547,7 @@ Second paragraph with *italic* text.`;
 			const profile = await mockSubstackClient.ownProfile();
 			const noteBuilder = profile.newNote();
 			
-			const result = await MarkdownParser.parseMarkdownToNoteStructured(markdown, noteBuilder);
+			const result = MarkdownParser.parseMarkdownToNoteStructured(markdown, noteBuilder);
 			await result.publish();
 
 			expect(capturedPayload).toMatchObject(expectedJson);
@@ -591,7 +591,7 @@ Second paragraph with *italic* text.`;
 			const profile = await mockSubstackClient.ownProfile();
 			const noteBuilder = profile.newNote();
 			
-			const result = await MarkdownParser.parseMarkdownToNoteStructured(markdown, noteBuilder);
+			const result = MarkdownParser.parseMarkdownToNoteStructured(markdown, noteBuilder);
 			await result.publish();
 
 			expect(capturedPayload).toMatchObject(expectedJson);
@@ -622,7 +622,7 @@ Second paragraph with *italic* text.`;
 			const profile = await mockSubstackClient.ownProfile();
 			const noteBuilder = profile.newNote();
 			
-			const result = await MarkdownParser.parseMarkdownToNoteStructured(markdown, noteBuilder);
+			const result = MarkdownParser.parseMarkdownToNoteStructured(markdown, noteBuilder);
 			await result.publish();
 
 			expect(capturedPayload).toMatchObject(expectedJson);
@@ -728,7 +728,7 @@ Final paragraph.`;
 			const profile = await mockSubstackClient.ownProfile();
 			const noteBuilder = profile.newNote();
 			
-			const result = await MarkdownParser.parseMarkdownToNoteStructured(markdown, noteBuilder);
+			const result = MarkdownParser.parseMarkdownToNoteStructured(markdown, noteBuilder);
 			await result.publish();
 
 			expect(capturedPayload).toMatchObject(expectedJson);
@@ -740,28 +740,36 @@ Final paragraph.`;
 			const profile = await mockSubstackClient.ownProfile();
 			const noteBuilder = profile.newNote();
 			
-			await expect(MarkdownParser.parseMarkdownToNoteStructured('', noteBuilder)).rejects.toThrow('Note body cannot be empty - at least one paragraph with content is required');
+			expect(() => {
+				MarkdownParser.parseMarkdownToNoteStructured('', noteBuilder);
+			}).toThrow('Note body cannot be empty - at least one paragraph with content is required');
 		});
 
 		it('should throw error for whitespace-only markdown', async () => {
 			const profile = await mockSubstackClient.ownProfile();
 			const noteBuilder = profile.newNote();
 			
-			await expect(MarkdownParser.parseMarkdownToNoteStructured('   \n\t  ', noteBuilder)).rejects.toThrow('Note body cannot be empty - at least one paragraph with content is required');
+			expect(() => {
+				MarkdownParser.parseMarkdownToNoteStructured('   \n\t  ', noteBuilder);
+			}).toThrow('Note body cannot be empty - at least one paragraph with content is required');
 		});
 
 		it('should throw error for empty headings', async () => {
 			const profile = await mockSubstackClient.ownProfile();
 			const noteBuilder = profile.newNote();
 			
-			await expect(MarkdownParser.parseMarkdownToNoteStructured('## \n### \n#### ', noteBuilder)).rejects.toThrow('Note must contain at least one paragraph with actual content');
+			expect(() => {
+				MarkdownParser.parseMarkdownToNoteStructured('## \n### \n#### ', noteBuilder);
+			}).toThrow('Note must contain at least one paragraph with actual content');
 		});
 
 		it('should throw error for empty list items only', async () => {
 			const profile = await mockSubstackClient.ownProfile();
 			const noteBuilder = profile.newNote();
 			
-			await expect(MarkdownParser.parseMarkdownToNoteStructured('- \n* \n1. ', noteBuilder)).rejects.toThrow('Note must contain at least one paragraph with actual content');
+			expect(() => {
+				MarkdownParser.parseMarkdownToNoteStructured('- \n* \n1. ', noteBuilder);
+			}).toThrow('Note must contain at least one paragraph with actual content');
 		});
 	});
 });


### PR DESCRIPTION
- Downgrade marked from ^16.1.1 to ^4.3.0 for n8n compatibility
- Downgrade @types/marked from ^5.0.2 to ^4.3.2 to match
- Revert to simple import statements instead of dynamic imports
- Remove async/await from MarkdownParser methods (back to synchronous)
- Update all test calls to remove await and use synchronous error handling
- Resolves ES module import issues in n8n deployment environment