### PR TITLE
feat: update substack-api to 1.4.0 and add link attachment support

### DIFF
--- a/nodes/Substack/Note.fields.ts
+++ b/nodes/Substack/Note.fields.ts
@@ -75,6 +75,47 @@ export const noteFields: INodeProperties[] = [
 			},
 		],
 	},
+	{
+		displayName: 'Attachment',
+		name: 'attachment',
+		type: 'options',
+		default: 'none',
+		description: 'Add an attachment to the note',
+		displayOptions: {
+			show: {
+				resource: ['note'],
+				operation: ['create'],
+			},
+		},
+		options: [
+			{
+				name: 'None',
+				value: 'none',
+				description: 'No attachment',
+			},
+			{
+				name: 'Link',
+				value: 'link',
+				description: 'Attach a link to the note',
+			},
+		],
+	},
+	{
+		displayName: 'Link URL',
+		name: 'linkUrl',
+		type: 'string',
+		default: '',
+		description: 'URL to attach to the note',
+		displayOptions: {
+			show: {
+				resource: ['note'],
+				operation: ['create'],
+				attachment: ['link'],
+			},
+		},
+		required: true,
+		placeholder: 'https://example.com',
+	},
 	/* -------------------------------------------------------------------------- */
 	/*                              note:get                                     */
 	/* -------------------------------------------------------------------------- */

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "marked": "^4.3.0",
-        "substack-api": "^1.3.0",
+        "substack-api": "^1.4.0",
         "turndown": "^7.2.0"
       },
       "devDependencies": {
@@ -8300,9 +8300,9 @@
       }
     },
     "node_modules/substack-api": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/substack-api/-/substack-api-1.3.0.tgz",
-      "integrity": "sha512-CVOQ1yI6XX0dMgz0sYhtijZZ6EzSTGq1c7W5o8+uIcA/tWYcT/EIffNUsqwWGYXek7iEmEE80odXA74oc4LQiw==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/substack-api/-/substack-api-1.4.0.tgz",
+      "integrity": "sha512-vaVOtddr1hyq3G28l0T5PosOhYtR2Vw4ZWKtkisAhDP5Ap7ShH11NUCOXGnfeHBjyDiC+3jGlExqoasV5Shcug==",
       "license": "MIT",
       "dependencies": {
         "fp-ts": "^2.16.10",
@@ -8681,9 +8681,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
-      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
+      "version": "5.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
+      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
   },
   "dependencies": {
     "marked": "^4.3.0",
-    "substack-api": "^1.3.0",
+    "substack-api": "^1.4.0",
     "turndown": "^7.2.0"
   }
 }


### PR DESCRIPTION
## Summary
- Updated substack-api dependency from 1.3.0 to 1.4.0
- Added link attachment support for note creation using new `newNoteWithLink` method
- Enhanced UI with conditional Attachment and Link URL fields

## Changes
- Bumped substack-api to version 1.4.0 in package.json
- Added Attachment field with None/Link options to Note creation
- Added conditional Link URL field that appears when Link attachment is selected
- Updated note operations to use `newNoteWithLink()` when URL is provided
- Enhanced both simple and advanced note creation modes to support link attachments
- Updated response format to include attachment and linkUrl fields

## Test plan
- [x] All existing tests pass
- [x] Build succeeds without errors
- [x] TypeScript compilation passes
- [ ] Manual testing of note creation with link attachments
- [ ] Verify link attachments appear correctly in Substack interface