### PR TITLE
fix: update cookie name to substack.sid

### DIFF
--- a/credentials/SubstackApi.credentials.ts
+++ b/credentials/SubstackApi.credentials.ts
@@ -39,7 +39,7 @@ export class SubstackApi implements ICredentialType {
 		type: 'generic',
 		properties: {
 			headers: {
-				Cookie: '=connect.sid={{$credentials.apiKey}}',
+				Cookie: '=substack.sid={{$credentials.apiKey}}',
 			},
 		},
 	};
@@ -50,7 +50,7 @@ export class SubstackApi implements ICredentialType {
 			url: '/api/v1/subscription',
 			method: 'GET',
 			headers: {
-				Cookie: '=connect.sid={{$credentials.apiKey}}',
+				Cookie: '=substack.sid={{$credentials.apiKey}}',
 			},
 		},
 	};


### PR DESCRIPTION
I noticed the cookie name has changed as I tried this n8n node for the first time. I haven't tested this e2e as I'm pretty new to n8n in general but I thought this is where the test request might fail.